### PR TITLE
fix: mkdtempDisposable usage

### DIFF
--- a/packages/backend/src/services/syft-service.spec.ts
+++ b/packages/backend/src/services/syft-service.spec.ts
@@ -143,6 +143,8 @@ describe('SyftService#analyse', () => {
       undefined,
     );
 
+    expect(mkdtempDisposable).toHaveBeenCalledExactlyOnceWith(join(tmpdir(), IMAGE_INFO_MOCK.engineId));
+
     const dest = join(tmpdir(), IMAGE_INFO_MOCK.engineId, 'foo.syft.json');
     const tmp = `${dest}.tmp`;
 

--- a/packages/backend/src/services/syft-service.ts
+++ b/packages/backend/src/services/syft-service.ts
@@ -32,6 +32,7 @@ import { inject, injectable, postConstruct, preDestroy } from 'inversify';
 import { mkdir, mkdtempDisposable, rename } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 
 @injectable()
 export class SyftService extends AnchoreCliService {
@@ -119,7 +120,8 @@ export class SyftService extends AnchoreCliService {
         });
         if (token.isCancellationRequested) throw new Error('cannot analyse image: cancellation has been requested');
 
-        await using dir = await mkdtempDisposable(image.engineId);
+        // create a tmp directory that will be disposed / removed on function exit
+        await using dir = await mkdtempDisposable(join(tmpdir(), image.engineId));
         const tarball = join(dir.path, image.Id);
 
         progress.report({ message: `Saving image ${imageName}` });


### PR DESCRIPTION
## Description

As raised in https://github.com/podman-desktop/extension-grype/pull/22#pullrequestreview-3904651239 the usage of `mkdtempDisposable` was incorrect.

## Related issues

Fixes https://github.com/podman-desktop/extension-grype/issues/25