### PR TITLE
feat(grype): add analyse method

### DIFF
--- a/packages/backend/src/services/grype-service.spec.ts
+++ b/packages/backend/src/services/grype-service.spec.ts
@@ -88,7 +88,7 @@ describe('GrypeService#analyse', () => {
   test('non-existent sbom should throw an error', async () => {
     await expect(async () => {
       await grype.analyse('fake');
-    }).rejects.toThrowError('cannot analyse image without sbom file');
+    }).rejects.toThrowError('cannot analyse without sbom file');
   });
 
   test('existing sbom and cached grype output should return it', async () => {

--- a/packages/backend/src/services/grype-service.ts
+++ b/packages/backend/src/services/grype-service.ts
@@ -77,18 +77,18 @@ export class GrypeService extends AnchoreCliService {
     },
   ): Promise<GrypeOutput> {
     if (!this.cliTool?.version || !this.cliTool.path)
-      throw new Error('cannot analyse image without syft binary installed');
+      throw new Error('cannot analyse sbom without grype binary installed');
 
     const cancel = new CancellationTokenSource();
     options?.token?.onCancellationRequested(() => {
       cancel.cancel();
     });
     if (options?.token?.isCancellationRequested)
-      throw new Error('cannot analyse image: cancellation has been requested');
+      throw new Error('cannot analyse sbom: cancellation has been requested');
 
     const binary = this.cliTool.path;
 
-    if (!existsSync(sbom)) throw new Error('cannot analyse image without sbom file');
+    if (!existsSync(sbom)) throw new Error('cannot analyse without sbom file');
 
     const dir = dirname(sbom);
     const [name] = basename(sbom).split('.');


### PR DESCRIPTION
## Description

Adding the `analyse` method for the Grype service, it takes as argument an SBOM file generated by syft.

## Related issues

Fixes https://github.com/podman-desktop/extension-grype/issues/17

## Testing

- [x] unit testing have been provided

Full feature can be tested in https://github.com/podman-desktop/extension-grype/pull/22