### PR TITLE
refactor(zod/grype): rename and refine grype schema

### DIFF
--- a/packages/backend/src/schemas/grype.ts
+++ b/packages/backend/src/schemas/grype.ts
@@ -17,37 +17,36 @@
  ***********************************************************************/
 import { z } from 'zod';
 
+function normalizeSeverity(severity?: string): 'high' | 'critical' | 'medium' | 'low' | undefined {
+  switch (severity?.toLowerCase()) {
+    case 'high':
+      return 'high';
+    case 'critical':
+      return 'critical';
+    case 'medium':
+      return 'medium';
+    case 'low':
+    case 'negligible':
+      return 'low';
+    default:
+      return undefined;
+  }
+}
+
 /**
  * No json-schema is provided for grype json output
  * Waiting on upstream https://github.com/anchore/grype/issues/214
  */
-export const GrypeOutputSchema = z.object({
+export const GrypeDocumentSchema = z.object({
   matches: z.array(
     z.object({
       vulnerability: z.object({
         id: z.string(),
-        severity: z
-          .string()
-          .optional()
-          .transform(severity => {
-            switch (severity?.toLowerCase()) {
-              case 'high':
-                return 'high';
-              case 'critical':
-                return 'critical';
-              case 'medium':
-                return 'medium';
-              case 'low':
-              case 'negligible':
-                return 'low';
-              default:
-                return undefined;
-            }
-          }),
+        severity: z.string().optional().transform(normalizeSeverity),
         description: z.string().optional(),
       }),
     }),
   ),
 });
 
-export type GrypeOutput = z.output<typeof GrypeOutputSchema>;
+export type Document = z.output<typeof GrypeDocumentSchema>;

--- a/packages/backend/src/services/grype-service.spec.ts
+++ b/packages/backend/src/services/grype-service.spec.ts
@@ -24,13 +24,13 @@ import { tmpdir } from 'node:os';
 import type { Octokit } from '@octokit/rest';
 import { existsSync } from 'node:fs';
 import { GrypeService } from '/@/services/grype-service';
-import type { GrypeOutput } from '/@/schemas/grype-output';
+import type * as grype from '/@/schemas/grype';
 import { readFile } from 'node:fs/promises';
 
 vi.mock(import('node:fs'));
 vi.mock(import('node:fs/promises'));
 
-const GRYPE_DOCUMENT_MOCK: GrypeOutput = {
+const GRYPE_DOCUMENT_MOCK: grype.Document = {
   matches: [],
 };
 const EXTENSION_CONTEXT_MOCK: ExtensionContext = {
@@ -69,32 +69,32 @@ const CLI_TOOL_MOCK: CliTool = {
   dispose: vi.fn(),
 };
 
-let grype: GrypeService;
+let grypeService: GrypeService;
 
 beforeEach(() => {
   vi.resetAllMocks();
 
   vi.mocked(cliApi.createCliTool).mockReturnValue(CLI_TOOL_MOCK);
-  grype = new GrypeService(OCTOKIT_MOCK, EXTENSION_CONTEXT_MOCK);
+  grypeService = new GrypeService(OCTOKIT_MOCK, EXTENSION_CONTEXT_MOCK);
 
   vi.mocked(readFile).mockResolvedValue(JSON.stringify(GRYPE_DOCUMENT_MOCK));
 });
 
 describe('GrypeService#analyse', () => {
   beforeEach(() => {
-    return grype.init();
+    return grypeService.init();
   });
 
   test('non-existent sbom should throw an error', async () => {
     await expect(async () => {
-      await grype.analyse('fake');
+      await grypeService.analyse('fake');
     }).rejects.toThrowError('cannot analyse without sbom file');
   });
 
   test('existing sbom and cached grype output should return it', async () => {
     vi.mocked(existsSync).mockReturnValue(true);
 
-    const result = await grype.analyse('foo.syft.json');
+    const result = await grypeService.analyse('foo.syft.json');
 
     expect(result).toStrictEqual(GRYPE_DOCUMENT_MOCK);
   });
@@ -102,7 +102,7 @@ describe('GrypeService#analyse', () => {
   test('should create a task', async () => {
     vi.mocked(existsSync).mockReturnValueOnce(true);
 
-    await grype.analyse('foo.syft.json');
+    await grypeService.analyse('foo.syft.json');
 
     expect(windowApi.withProgress).toHaveBeenCalledExactlyOnceWith(
       {
@@ -118,7 +118,7 @@ describe('GrypeService#analyse', () => {
     vi.mocked(existsSync).mockReturnValueOnce(true);
 
     const sbom = 'foo.syft.json';
-    await grype.analyse(sbom);
+    await grypeService.analyse(sbom);
 
     const fn = vi.mocked(windowApi.withProgress).mock.calls[0][1];
     assert(fn);

--- a/packages/backend/src/services/grype-service.ts
+++ b/packages/backend/src/services/grype-service.ts
@@ -31,7 +31,7 @@ import { inject, injectable, postConstruct, preDestroy } from 'inversify';
 import { existsSync } from 'node:fs';
 import { basename, dirname, join } from 'node:path';
 import { readFile } from 'node:fs/promises';
-import { GrypeOutput, GrypeOutputSchema } from '/@/schemas/grype-output';
+import * as grype from '/@/schemas/grype';
 
 @injectable()
 export class GrypeService extends AnchoreCliService {
@@ -75,7 +75,7 @@ export class GrypeService extends AnchoreCliService {
     options?: {
       token?: CancellationToken;
     },
-  ): Promise<GrypeOutput> {
+  ): Promise<grype.Document> {
     if (!this.cliTool?.version || !this.cliTool.path)
       throw new Error('cannot analyse sbom without grype binary installed');
 
@@ -96,7 +96,7 @@ export class GrypeService extends AnchoreCliService {
 
     if (existsSync(destination)) {
       const data = await readFile(destination, 'utf-8');
-      return GrypeOutputSchema.parse(JSON.parse(data));
+      return grype.GrypeDocumentSchema.parse(JSON.parse(data));
     }
 
     return window.withProgress(
@@ -116,7 +116,7 @@ export class GrypeService extends AnchoreCliService {
         });
 
         const content = await readFile(destination, 'utf-8');
-        return GrypeOutputSchema.parse(JSON.parse(content));
+        return grype.GrypeDocumentSchema.parse(JSON.parse(content));
       },
     );
   }


### PR DESCRIPTION
## Description

This is a part of https://github.com/podman-desktop/extension-grype/pull/30.

The current name of the grype schema is `GrypeOutputSchema` and the corresponding type `GrypeOutput` but the official name from the json schema is `Document`. 

As we want to replace it with the official json-schema later (see https://github.com/podman-desktop/extension-grype/issues/20). Let's use the same naming, so we don't need to make a breaking change when the types will be available.

> ⚠️ I also extracted the normalizeSeverity logic. There is a limitation with zod and vite that makes the types a bit broken when inline transform, extracting fix the problem;