### PR TITLE
refactor: move vite syft-json-schema to packages/api

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -15,3 +15,5 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+// export syft
+export type * as syft from './generated/syft-schema';

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../tsconfig.node.json",
+  "compilerOptions": {
+    "baseUrl": "."
+  },
   "include": ["src"],
   "exclude": ["vite.config.ts"]
 }

--- a/packages/api/vite-plugins/syft-json-schema.ts
+++ b/packages/api/vite-plugins/syft-json-schema.ts
@@ -28,7 +28,7 @@ export function syftJSONSchema(): Plugin {
     name: 'vite-plugin-syft-json-schema',
     enforce: 'pre',
     configResolved: async (resolved): Promise<void> => {
-      const generated = join(resolved.root, 'generated');
+      const generated = join(resolved.root, 'src', 'generated');
       await mkdir(generated, { recursive: true });
 
       const schemaPath = join(generated, 'syft-schema.json');

--- a/packages/api/vite.config.ts
+++ b/packages/api/vite.config.ts
@@ -17,6 +17,7 @@
  ***********************************************************************/
 import { join } from 'node:path';
 import { defineConfig } from 'vite';
+import { syftJSONSchema } from './vite-plugins/syft-json-schema';
 import dts from 'unplugin-dts/vite';
 import { builtinModules } from 'node:module';
 
@@ -26,6 +27,7 @@ export default defineConfig({
   mode: process.env.MODE,
   root: PACKAGE_ROOT,
   plugins: [
+    syftJSONSchema(),
     dts({
       root: PACKAGE_ROOT,
       tsconfigPath: join(PACKAGE_ROOT, 'tsconfig.json'),

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -4,10 +4,9 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "paths": {
-      "/@/*": ["./src/*"],
-      "/@generated/*": ["./generated/*"]
+      "/@/*": ["./src/*"]
     }
   },
   "include": ["src", "types/*.d.ts", "../../types/*.d.ts"],
-  "exclude": ["vite.config.ts", "vitest.config.ts", "vite-plugins/**/*.ts"]
+  "exclude": ["vite.config.ts", "vitest.config.ts"]
 }

--- a/packages/backend/vite.config.ts
+++ b/packages/backend/vite.config.ts
@@ -18,18 +18,15 @@
 import { join } from 'node:path';
 import { builtinModules } from 'node:module';
 import { defineConfig } from 'vite';
-import { syftJSONSchema } from './vite-plugins/syft-json-schema';
 
 const PACKAGE_ROOT = __dirname;
 
 export default defineConfig({
   mode: process.env.MODE,
   root: PACKAGE_ROOT,
-  plugins: [syftJSONSchema()],
   resolve: {
     alias: {
       '/@/': join(PACKAGE_ROOT, 'src') + '/',
-      '/@generated/': join(PACKAGE_ROOT, 'generated') + '/',
     },
   },
   build: {


### PR DESCRIPTION
## Description

Required for https://github.com/podman-desktop/extension-grype/pull/30

Moving the `syft-json-schema` vite plugin, (responsible of generating the types corresponding to the syft output command), from the `packages/backend` to `packages/api`.