### PR TITLE
fix: resolve CVE-2026-32141 in flatted

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
   },
   "pnpm": {
     "overrides": {
-      "minimatch@>=9.0.0 <9.0.6": "9.0.6"
+      "minimatch@>=9.0.0 <9.0.6": "9.0.6",
+      "flatted@<3.4.0": ">=3.4.0"
     }
   },
   "packageManager": "pnpm@10.15.0+sha512.486ebc259d3e999a4e8691ce03b5cac4a71cbeca39372a9b762cb500cfdf0873e2cb16abe3d951b1ee2cf012503f027b98b6584e4df22524e0c7450d9ec7aa7b"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   string-width: ^4.2.0
   wrap-ansi: ^7.0.0
   minimatch@>=9.0.0 <9.0.6: 9.0.6
+  flatted@<3.4.0: '>=3.4.0'
 
 importers:
 
@@ -1794,8 +1795,8 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flatted@3.3.4:
-    resolution: {integrity: sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==}
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
@@ -4767,10 +4768,10 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.3.4
+      flatted: 3.4.2
       keyv: 4.5.4
 
-  flatted@3.3.4: {}
+  flatted@3.4.2: {}
 
   for-each@0.3.5:
     dependencies:


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability CVE-2026-32141 in `flatted`.

**Advisory**: flatted vulnerable to unbounded recursion DoS in parse() revive phase
**Vulnerable versions**: <3.4.0
**Patched versions**: >=3.4.0
**Advisory URL**: https://github.com/advisories/GHSA-25h7-pfq9-p65f

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-32141: _flatted vulnerable to unbounded recursion DoS in parse() revive phase_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-32141 is no longer reported