### PR TITLE
fix: resolve CVE-2026-33671 in picomatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
   "pnpm": {
     "overrides": {
       "minimatch@>=9.0.0 <9.0.6": "9.0.6",
-      "flatted@<3.4.0": ">=3.4.0"
+      "flatted@<3.4.0": ">=3.4.0",
+      "picomatch@>=4.0.0 <4.0.4": "4.0.4"
     }
   },
   "packageManager": "pnpm@10.15.0+sha512.486ebc259d3e999a4e8691ce03b5cac4a71cbeca39372a9b762cb500cfdf0873e2cb16abe3d951b1ee2cf012503f027b98b6584e4df22524e0c7450d9ec7aa7b"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   wrap-ansi: ^7.0.0
   minimatch@>=9.0.0 <9.0.6: 9.0.6
   flatted@<3.4.0: '>=3.4.0'
+  picomatch@>=4.0.0 <4.0.4: 4.0.4
 
 importers:
 
@@ -1770,7 +1771,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: 4.0.4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -2376,10 +2377,6 @@ packages:
   picomatch@2.3.2:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
-
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
@@ -4743,10 +4740,6 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
-  fdir@6.5.0(picomatch@4.0.3):
-    optionalDependencies:
-      picomatch: 4.0.3
-
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -5337,8 +5330,6 @@ snapshots:
 
   picomatch@2.3.2: {}
 
-  picomatch@4.0.3: {}
-
   picomatch@4.0.4: {}
 
   pkg-types@1.3.1:
@@ -5741,8 +5732,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinyglobby@0.2.16:
     dependencies:
@@ -5956,7 +5947,7 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 1.0.2


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability CVE-2026-33671 in `picomatch`.

**Advisory**: Picomatch has a ReDoS vulnerability via extglob quantifiers
**Vulnerable versions**: >=4.0.0 <4.0.4
**Patched versions**: >=4.0.4
**Advisory URL**: https://github.com/advisories/GHSA-c2c7-rcm5-vvqj

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-33671: _Picomatch has a ReDoS vulnerability via extglob quantifiers_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-33671 is no longer reported