### PR TITLE
fix: resolve CVE-2026-4800 in lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "overrides": {
       "minimatch@>=9.0.0 <9.0.6": "9.0.6",
       "flatted@<3.4.0": ">=3.4.0",
-      "picomatch@>=4.0.0 <4.0.4": "4.0.4"
+      "picomatch@>=4.0.0 <4.0.4": "4.0.4",
+      "lodash@>=4.0.0 <=4.17.23": ">=4.18.0"
     }
   },
   "packageManager": "pnpm@10.15.0+sha512.486ebc259d3e999a4e8691ce03b5cac4a71cbeca39372a9b762cb500cfdf0873e2cb16abe3d951b1ee2cf012503f027b98b6584e4df22524e0c7450d9ec7aa7b"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   minimatch@>=9.0.0 <9.0.6: 9.0.6
   flatted@<3.4.0: '>=3.4.0'
   picomatch@>=4.0.0 <4.0.4: 4.0.4
+  lodash@>=4.0.0 <=4.17.23: '>=4.18.0'
 
 importers:
 
@@ -2226,8 +2227,8 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
@@ -3320,7 +3321,7 @@ snapshots:
       '@rushstack/terminal': 0.22.3(@types/node@24.12.2)
       '@rushstack/ts-command-line': 5.3.3(@types/node@24.12.2)
       diff: 8.0.4
-      lodash: 4.17.23
+      lodash: 4.18.1
       minimatch: 10.2.3
       resolve: 1.22.12
       semver: 7.5.4
@@ -5075,7 +5076,7 @@ snapshots:
       '@types/lodash': 4.17.24
       is-glob: 4.0.3
       js-yaml: 4.1.1
-      lodash: 4.17.23
+      lodash: 4.18.1
       minimist: 1.2.8
       prettier: 3.8.1
       tinyglobby: 0.2.15
@@ -5180,7 +5181,7 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
-  lodash@4.17.23: {}
+  lodash@4.18.1: {}
 
   lru-cache@6.0.0:
     dependencies:


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability CVE-2026-4800 in `lodash`.

**Advisory**: lodash vulnerable to Code Injection via `_.template` imports key names
**Vulnerable versions**: >=4.0.0 <=4.17.23
**Patched versions**: >=4.18.0
**Advisory URL**: https://github.com/advisories/GHSA-r5fr-rjxr-66jc

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-4800: _lodash vulnerable to Code Injection via `_.template` imports key names_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-4800 is no longer reported