### PR TITLE
chore: add dependabot groups for vitest and eslint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,19 @@ updates:
       # check at 3am UTC
       time: "03:00"
     open-pull-requests-limit: 10
+    groups:
+      vitest:
+        applies-to: version-updates
+        patterns:
+          - "@vitest/*"
+          - "vitest"
+      eslint:
+        applies-to: version-updates
+        patterns:
+          - "@eslint/*"
+          - "eslint"
+      typescript-eslint:
+        applies-to: version-updates
+        patterns:
+          - "@typescript-eslint/*"
+          - "typescript-eslint"


### PR DESCRIPTION
## Summary

- Add `groups` configuration to `dependabot.yml` for **vitest**, **eslint**, and **typescript-eslint** packages
- Without groups, dependabot silently fails to open PRs for tightly coupled packages (e.g. `vitest` + `@vitest/coverage-v8`) because it cannot resolve peer dependencies when updating them independently
- Aligns with the grouping convention already used in [podman-desktop](https://github.com/podman-desktop/podman-desktop/blob/main/.github/dependabot.yml)

## Test plan

- [ ] Verify dependabot opens grouped PRs for vitest and eslint packages on the next daily run


Made with [Cursor](https://cursor.com)