### PR TITLE
fix: resolve CVE-2026-33750 in brace-expansion 

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
       "minimatch@>=9.0.0 <9.0.6": "9.0.6",
       "flatted@<3.4.0": ">=3.4.0",
       "picomatch@>=4.0.0 <4.0.4": "4.0.4",
-      "lodash@>=4.0.0 <=4.17.23": ">=4.18.0"
+      "lodash@>=4.0.0 <=4.17.23": ">=4.18.0",
+      "brace-expansion@<1.1.13": "1.1.13"
     }
   },
   "packageManager": "pnpm@10.15.0+sha512.486ebc259d3e999a4e8691ce03b5cac4a71cbeca39372a9b762cb500cfdf0873e2cb16abe3d951b1ee2cf012503f027b98b6584e4df22524e0c7450d9ec7aa7b"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   flatted@<3.4.0: '>=3.4.0'
   picomatch@>=4.0.0 <4.0.4: 4.0.4
   lodash@>=4.0.0 <=4.17.23: '>=4.18.0'
+  brace-expansion@<1.1.13: 1.1.13
 
 importers:
 
@@ -1330,8 +1331,8 @@ packages:
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
 
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+  brace-expansion@1.1.13:
+    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -4172,7 +4173,7 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
-  brace-expansion@1.1.12:
+  brace-expansion@1.1.13:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -5222,7 +5223,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 1.1.13
 
   minimatch@9.0.6:
     dependencies:


### PR DESCRIPTION
### What does this PR do?

Fix moderate severity vulnerability CVE-2026-33750 in `brace-expansion`.

**Advisory**: brace-expansion: Zero-step sequence causes process hang and memory exhaustion
**Vulnerable versions**: <1.1.13
**Patched versions**: >=1.1.13
**Advisory URL**: https://github.com/advisories/GHSA-f886-m6hf-6m8v

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-33750: _brace-expansion: Zero-step sequence causes process hang and memory exhaustion_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-33750 is no longer reported