### PR TITLE
chore(pr-check): setting minimal permissions

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -19,6 +19,9 @@ name: pr-check
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   lint-format-unit:
     name: linter, formatter, and tests / ${{ matrix.os }}


### PR DESCRIPTION
Fixes https://github.com/podman-desktop/extension-grype/security/code-scanning/1