### PR TITLE
feat(cli): support install system wide

### DIFF
--- a/packages/backend/__mocks__/@podman-desktop/api.ts
+++ b/packages/backend/__mocks__/@podman-desktop/api.ts
@@ -77,6 +77,9 @@ const plugin = {
   version: version,
   env: {
     createTelemetryLogger: vi.fn(),
+    isWindows: false,
+    isLinux: false,
+    isMac: false,
   } as unknown as typeof podmanDesktopApi.env,
   process: {
     exec: vi.fn(),

--- a/packages/backend/src/services/anchore-cli-service.spec.ts
+++ b/packages/backend/src/services/anchore-cli-service.spec.ts
@@ -17,11 +17,16 @@
  ***********************************************************************/
 
 import { test, vi, beforeEach, expect, describe } from 'vitest';
-import { ANCHORE_GITHUB_ORG, AnchoreCliService, type GithubReleaseMetadata } from '/@/services/anchore-cli-service';
+import {
+  ANCHORE_GITHUB_ORG,
+  AnchoreCliService,
+  type GithubReleaseMetadata,
+  type InstallationInfo,
+} from '/@/services/anchore-cli-service';
 import { join } from 'node:path';
-import { tmpdir } from 'node:os';
+import { homedir } from 'node:os';
 import type { Octokit } from '@octokit/rest';
-import { cli as cliApi, process as processApi, window as windowApi } from '@podman-desktop/api';
+import { cli as cliApi, env as envApi, process as processApi, window as windowApi } from '@podman-desktop/api';
 import type { CliToolInstaller, CliTool, Logger, ExtensionContext, TelemetryLogger } from '@podman-desktop/api';
 import type { Endpoints } from '@octokit/types';
 import { existsSync } from 'node:fs';
@@ -33,6 +38,7 @@ import { TELEMETRY_EVENTS } from '/@/utils/telemetry';
 
 vi.mock(import('node:fs'));
 vi.mock(import('node:fs/promises'));
+vi.mock(import('node:os'));
 vi.mock(import('@octokit/rest'));
 vi.mock(import('adm-zip'), () => ({
   default: vi.fn(
@@ -44,7 +50,7 @@ vi.mock(import('adm-zip'), () => ({
 vi.mock(import('tar'));
 
 const EXTENSION_CONTEXT_MOCK: ExtensionContext = {
-  storagePath: join(tmpdir()),
+  storagePath: join('/tmp'),
 } as unknown as ExtensionContext;
 const OCTOKIT_MOCK: Octokit = {
   repos: {
@@ -76,6 +82,18 @@ class TestCli extends AnchoreCliService {
   }
   public get repoName(): string {
     return 'dummy';
+  }
+  public override getSystemBinaryPath(): string {
+    return super.getSystemBinaryPath();
+  }
+  public override where(): Promise<string | undefined> {
+    return super.where();
+  }
+  public override getInstalledInfo(): Promise<InstallationInfo> {
+    return super.getInstalledInfo();
+  }
+  public override installSystemWide(binaryPath: string): Promise<string | undefined> {
+    return super.installSystemWide(binaryPath);
   }
 }
 
@@ -142,6 +160,13 @@ beforeEach(() => {
 
   cli = new TestCli(OCTOKIT_MOCK, EXTENSION_CONTEXT_MOCK, TELEMETRY_LOGGER_MOCK);
 
+  // reset non-mock properties on shared CliTool object
+  CLI_TOOL_MOCK.path = undefined;
+  CLI_TOOL_MOCK.version = undefined;
+
+  // mock homedir
+  vi.mocked(homedir).mockReturnValue('/home/testuser');
+
   // mock fs
   vi.mocked(rm).mockResolvedValue(undefined);
 
@@ -176,7 +201,7 @@ describe('TestCli#init', () => {
         icon: CLI_TOOL_MOCK.images.icon,
         logo: CLI_TOOL_MOCK.images.logo,
       },
-      installationSource: 'extension',
+      installationSource: undefined,
       markdownDescription: CLI_TOOL_MOCK.markdownDescription,
       name: CLI_TOOL_MOCK.name,
       path: undefined,
@@ -186,17 +211,21 @@ describe('TestCli#init', () => {
 
   test('registered cli should have version when existing version is found', async () => {
     vi.mocked(existsSync).mockReturnValue(true);
-    vi.mocked(processApi.exec).mockResolvedValue({
-      stdout: 'cli 1.41.2',
-      command: 'version',
-      stderr: '',
-    });
+    // where() throws → falls back to internalBinaryPath
+    vi.mocked(processApi.exec)
+      .mockRejectedValueOnce(new Error('not found'))
+      .mockResolvedValueOnce({
+        stdout: 'cli 1.41.2',
+        command: 'version',
+        stderr: '',
+      });
 
     await cli.init();
     expect(cliApi.createCliTool).toHaveBeenCalledExactlyOnceWith(
       expect.objectContaining({
         path: join(EXTENSION_CONTEXT_MOCK.storagePath, cli.toolId, 'dummy'),
         version: '1.41.2',
+        installationSource: 'extension',
       }),
     );
   });
@@ -379,4 +408,263 @@ test('TestCli#dispose should dispose CliTool', async () => {
   cli.dispose();
 
   expect(CLI_TOOL_MOCK.dispose).toHaveBeenCalledOnce();
+});
+
+describe('getSystemBinaryPath', () => {
+  test('should return /usr/local/bin path on Linux/Mac', () => {
+    Object.defineProperty(envApi, 'isWindows', { value: false, configurable: true });
+
+    expect(cli.getSystemBinaryPath()).toBe(join('/usr', 'local', 'bin', 'dummy'));
+  });
+
+  test('should return Windows AppData path with .exe on Windows', () => {
+    Object.defineProperty(envApi, 'isWindows', { value: true, configurable: true });
+
+    expect(cli.getSystemBinaryPath()).toBe(
+      join(homedir(), 'AppData', 'Local', 'Microsoft', 'WindowsApps', 'dummy.exe'),
+    );
+  });
+});
+
+describe('where', () => {
+  test('should return path from which on non-Windows', async () => {
+    Object.defineProperty(envApi, 'isWindows', { value: false, configurable: true });
+    vi.mocked(processApi.exec).mockResolvedValue({
+      stdout: '/usr/local/bin/dummy',
+      command: 'which',
+      stderr: '',
+    });
+
+    const result = await cli.where();
+    expect(result).toBe('/usr/local/bin/dummy');
+    expect(processApi.exec).toHaveBeenCalledWith('which', ['dummy']);
+  });
+
+  test('should return cleaned path from where on Windows', async () => {
+    Object.defineProperty(envApi, 'isWindows', { value: true, configurable: true });
+    vi.mocked(processApi.exec).mockResolvedValue({
+      stdout: 'C:\\Users\\test\\dummy.exe\r\n',
+      command: 'where',
+      stderr: '',
+    });
+
+    const result = await cli.where();
+    expect(result).toBe('C:\\Users\\test\\dummy.exe');
+    expect(processApi.exec).toHaveBeenCalledWith('where', ['dummy']);
+  });
+
+  test('should return undefined when exec throws', async () => {
+    vi.mocked(processApi.exec).mockRejectedValue(new Error('not found'));
+
+    const result = await cli.where();
+    expect(result).toBeUndefined();
+  });
+});
+
+describe('getInstalledInfo', () => {
+  test('should return source extension when where() finds binary at system binary path', async () => {
+    Object.defineProperty(envApi, 'isWindows', { value: false, configurable: true });
+    const systemPath = cli.getSystemBinaryPath();
+
+    vi.mocked(processApi.exec)
+      .mockResolvedValueOnce({ stdout: systemPath, command: 'which', stderr: '' })
+      .mockResolvedValueOnce({ stdout: 'dummy 1.2.3', command: 'version', stderr: '' });
+
+    const info = await cli.getInstalledInfo();
+    expect(info).toEqual({
+      path: systemPath,
+      version: '1.2.3',
+      source: 'extension',
+    });
+  });
+
+  test('should return source external when where() finds binary at different path', async () => {
+    Object.defineProperty(envApi, 'isWindows', { value: false, configurable: true });
+
+    vi.mocked(processApi.exec)
+      .mockResolvedValueOnce({ stdout: '/custom/path/dummy', command: 'which', stderr: '' })
+      .mockResolvedValueOnce({ stdout: 'dummy 2.0.0', command: 'version', stderr: '' });
+
+    const info = await cli.getInstalledInfo();
+    expect(info).toEqual({
+      path: '/custom/path/dummy',
+      version: '2.0.0',
+      source: 'external',
+    });
+  });
+
+  test('should fallback to internalBinaryPath when where() returns undefined', async () => {
+    vi.mocked(processApi.exec)
+      .mockRejectedValueOnce(new Error('not found'))
+      .mockResolvedValueOnce({ stdout: 'dummy 3.0.0', command: 'version', stderr: '' });
+
+    const info = await cli.getInstalledInfo();
+    expect(info).toEqual({
+      path: join(EXTENSION_CONTEXT_MOCK.storagePath, 'dummy', 'dummy'),
+      version: '3.0.0',
+      source: 'extension',
+    });
+  });
+
+  test('should use full stdout when version cannot be parsed', async () => {
+    vi.mocked(processApi.exec)
+      .mockRejectedValueOnce(new Error('not found'))
+      .mockResolvedValueOnce({ stdout: 'unparseable', command: 'version', stderr: '' });
+
+    const info = await cli.getInstalledInfo();
+    expect(info.version).toBe('unparseable');
+  });
+});
+
+describe('installSystemWide', () => {
+  test('should use cp with admin privileges on Linux/Mac', async () => {
+    Object.defineProperty(envApi, 'isWindows', { value: false, configurable: true });
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(processApi.exec).mockResolvedValue({ stdout: '', command: 'cp', stderr: '' });
+
+    const result = await cli.installSystemWide('/tmp/dummy');
+    expect(result).toBe(join('/usr', 'local', 'bin', 'dummy'));
+    expect(processApi.exec).toHaveBeenCalledWith('cp', ['/tmp/dummy', join('/usr', 'local', 'bin', 'dummy')], {
+      isAdmin: true,
+    });
+  });
+
+  test('should use copy with quoted paths on Windows', async () => {
+    Object.defineProperty(envApi, 'isWindows', { value: true, configurable: true });
+    Object.defineProperty(envApi, 'isLinux', { value: false, configurable: true });
+    Object.defineProperty(envApi, 'isMac', { value: false, configurable: true });
+    vi.mocked(processApi.exec).mockResolvedValue({ stdout: '', command: 'copy', stderr: '' });
+
+    const destPath = join(homedir(), 'AppData', 'Local', 'Microsoft', 'WindowsApps', 'dummy.exe');
+    const result = await cli.installSystemWide('C:\\tmp\\dummy.exe');
+    expect(result).toBe(destPath);
+    expect(processApi.exec).toHaveBeenCalledWith('copy', [`"C:\\tmp\\dummy.exe"`, `"${destPath}"`], {
+      isAdmin: true,
+    });
+  });
+
+  test('should create /usr/local/bin when it does not exist on Linux', async () => {
+    Object.defineProperty(envApi, 'isWindows', { value: false, configurable: true });
+    Object.defineProperty(envApi, 'isLinux', { value: true, configurable: true });
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(processApi.exec).mockResolvedValue({ stdout: '', command: '', stderr: '' });
+
+    await cli.installSystemWide('/tmp/dummy');
+
+    expect(processApi.exec).toHaveBeenCalledWith('mkdir', ['-p', '/usr/local/bin'], { isAdmin: true });
+  });
+
+  test('should rethrow on copy failure', async () => {
+    Object.defineProperty(envApi, 'isWindows', { value: false, configurable: true });
+    vi.mocked(existsSync).mockReturnValue(true);
+    const error = new Error('permission denied');
+    vi.mocked(processApi.exec).mockRejectedValue(error);
+
+    await expect(cli.installSystemWide('/tmp/dummy')).rejects.toThrow('permission denied');
+  });
+});
+
+describe('install system-wide prompt', () => {
+  beforeEach(async () => {
+    await cli.init();
+
+    vi.mocked(windowApi.showQuickPick).mockResolvedValue({
+      label: LIST_RELEASES[0].name,
+      tag: LIST_RELEASES[0].tag_name,
+      id: LIST_RELEASES[0].id,
+    } as GithubReleaseMetadata);
+  });
+
+  test('should prompt user for system-wide install', async () => {
+    vi.mocked(windowApi.showInformationMessage).mockResolvedValue('Cancel');
+
+    await cli.install(
+      { label: 'v1.0.0', tag: 'v1.0.0', id: 0 },
+      { logger: LOGGER_MOCK },
+    );
+
+    expect(windowApi.showInformationMessage).toHaveBeenCalledWith(
+      'Do you want to install dummy system-wide?',
+      'Cancel',
+      'Confirm',
+    );
+  });
+
+  test('should install system-wide and use returned path when user confirms', async () => {
+    vi.mocked(windowApi.showInformationMessage).mockResolvedValue('Confirm');
+    Object.defineProperty(envApi, 'isWindows', { value: false, configurable: true });
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(processApi.exec).mockResolvedValue({ stdout: '', command: 'cp', stderr: '' });
+
+    await cli.install(
+      { label: 'v1.0.0', tag: 'v1.0.0', id: 0 },
+      { logger: LOGGER_MOCK },
+    );
+
+    expect(processApi.exec).toHaveBeenCalledWith(
+      'cp',
+      expect.arrayContaining([join('/usr', 'local', 'bin', 'dummy')]),
+      { isAdmin: true },
+    );
+    expect(CLI_TOOL_MOCK.updateVersion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: join('/usr', 'local', 'bin', 'dummy'),
+      }),
+    );
+  });
+
+  test('should skip system-wide install when user cancels', async () => {
+    vi.mocked(windowApi.showInformationMessage).mockResolvedValue('Cancel');
+
+    await cli.install(
+      { label: 'v1.0.0', tag: 'v1.0.0', id: 0 },
+      { logger: LOGGER_MOCK },
+    );
+
+    expect(CLI_TOOL_MOCK.updateVersion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: join(EXTENSION_CONTEXT_MOCK.storagePath, 'dummy', 'dummy'),
+      }),
+    );
+  });
+});
+
+describe('doUninstall system binary removal', () => {
+  let installer: CliToolInstaller;
+
+  beforeEach(async () => {
+    await cli.init();
+    installer = vi.mocked(CLI_TOOL_MOCK.registerInstaller).mock.calls[0][0];
+  });
+
+  test('should remove system binary with admin when cliTool.path matches system path', async () => {
+    Object.defineProperty(envApi, 'isWindows', { value: false, configurable: true });
+    const systemPath = cli.getSystemBinaryPath();
+    CLI_TOOL_MOCK.path = systemPath;
+    vi.mocked(processApi.exec).mockResolvedValue({ stdout: '', command: 'rm', stderr: '' });
+
+    await installer.doUninstall(LOGGER_MOCK);
+
+    expect(processApi.exec).toHaveBeenCalledWith('rm', [systemPath], { isAdmin: true });
+  });
+
+  test('should use del command on Windows for system binary removal', async () => {
+    Object.defineProperty(envApi, 'isWindows', { value: true, configurable: true });
+    const systemPath = cli.getSystemBinaryPath();
+    CLI_TOOL_MOCK.path = systemPath;
+    vi.mocked(processApi.exec).mockResolvedValue({ stdout: '', command: 'del', stderr: '' });
+
+    await installer.doUninstall(LOGGER_MOCK);
+
+    expect(processApi.exec).toHaveBeenCalledWith('del', [systemPath], { isAdmin: true });
+  });
+
+  test('should not attempt system binary removal when path does not match', async () => {
+    CLI_TOOL_MOCK.path = '/some/other/path';
+    vi.mocked(processApi.exec).mockResolvedValue({ stdout: '', command: '', stderr: '' });
+
+    await installer.doUninstall(LOGGER_MOCK);
+
+    expect(processApi.exec).not.toHaveBeenCalledWith('rm', expect.anything(), expect.anything());
+  });
 });

--- a/packages/backend/src/services/anchore-cli-service.spec.ts
+++ b/packages/backend/src/services/anchore-cli-service.spec.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+/* eslint-disable sonarjs/publicly-writable-directories */
+
 import { test, vi, beforeEach, expect, describe } from 'vitest';
 import {
   ANCHORE_GITHUB_ORG,
@@ -212,13 +214,11 @@ describe('TestCli#init', () => {
   test('registered cli should have version when existing version is found', async () => {
     vi.mocked(existsSync).mockReturnValue(true);
     // where() throws → falls back to internalBinaryPath
-    vi.mocked(processApi.exec)
-      .mockRejectedValueOnce(new Error('not found'))
-      .mockResolvedValueOnce({
-        stdout: 'cli 1.41.2',
-        command: 'version',
-        stderr: '',
-      });
+    vi.mocked(processApi.exec).mockRejectedValueOnce(new Error('not found')).mockResolvedValueOnce({
+      stdout: 'cli 1.41.2',
+      command: 'version',
+      stderr: '',
+    });
 
     await cli.init();
     expect(cliApi.createCliTool).toHaveBeenCalledExactlyOnceWith(
@@ -578,10 +578,7 @@ describe('install system-wide prompt', () => {
   test('should prompt user for system-wide install', async () => {
     vi.mocked(windowApi.showInformationMessage).mockResolvedValue('Cancel');
 
-    await cli.install(
-      { label: 'v1.0.0', tag: 'v1.0.0', id: 0 },
-      { logger: LOGGER_MOCK },
-    );
+    await cli.install({ label: 'v1.0.0', tag: 'v1.0.0', id: 0 }, { logger: LOGGER_MOCK });
 
     expect(windowApi.showInformationMessage).toHaveBeenCalledWith(
       'Do you want to install dummy system-wide?',
@@ -596,10 +593,7 @@ describe('install system-wide prompt', () => {
     vi.mocked(existsSync).mockReturnValue(true);
     vi.mocked(processApi.exec).mockResolvedValue({ stdout: '', command: 'cp', stderr: '' });
 
-    await cli.install(
-      { label: 'v1.0.0', tag: 'v1.0.0', id: 0 },
-      { logger: LOGGER_MOCK },
-    );
+    await cli.install({ label: 'v1.0.0', tag: 'v1.0.0', id: 0 }, { logger: LOGGER_MOCK });
 
     expect(processApi.exec).toHaveBeenCalledWith(
       'cp',
@@ -616,10 +610,7 @@ describe('install system-wide prompt', () => {
   test('should skip system-wide install when user cancels', async () => {
     vi.mocked(windowApi.showInformationMessage).mockResolvedValue('Cancel');
 
-    await cli.install(
-      { label: 'v1.0.0', tag: 'v1.0.0', id: 0 },
-      { logger: LOGGER_MOCK },
-    );
+    await cli.install({ label: 'v1.0.0', tag: 'v1.0.0', id: 0 }, { logger: LOGGER_MOCK });
 
     expect(CLI_TOOL_MOCK.updateVersion).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/backend/src/services/anchore-cli-service.ts
+++ b/packages/backend/src/services/anchore-cli-service.ts
@@ -16,15 +16,16 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import  {
-  CliTool, CliToolInstallationSource,
+import type {
+  CliTool,
+  CliToolInstallationSource,
   Disposable,
   ExtensionContext,
   Logger,
   QuickPickItem,
   TelemetryLogger,
 } from '@podman-desktop/api';
-import { cli as cliApi, env as envApi, process as processApi, window as windowApi } from '@podman-desktop/api';
+import extensionApi, { cli as cliApi, env as envApi, process as processApi, window as windowApi } from '@podman-desktop/api';
 import type { AsyncInit } from '/@/utils/async-init';
 import type { Octokit } from '@octokit/rest';
 import { arch as nodeArch, platform as nodePlatform } from 'node:process';
@@ -34,8 +35,7 @@ import * as tar from 'tar';
 import { chmod, mkdir, rm, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { TELEMETRY_EVENTS } from '/@/utils/telemetry';
-import {homedir} from "node:os";
-import extensionApi from "@podman-desktop/api";
+import { homedir } from 'node:os';
 
 export interface GithubReleaseMetadata extends QuickPickItem {
   tag: string;
@@ -43,7 +43,9 @@ export interface GithubReleaseMetadata extends QuickPickItem {
 }
 
 export interface InstallationInfo {
-  path: string; version: string; source: CliToolInstallationSource
+  path: string;
+  version: string;
+  source: CliToolInstallationSource;
 }
 
 export const ANCHORE_GITHUB_ORG = 'anchore';
@@ -67,14 +69,14 @@ export abstract class AnchoreCliService implements Disposable, AsyncInit {
   protected getSystemBinaryPath(): string {
     const binary = this.toolId;
 
-    if(envApi.isWindows) {
+    if (envApi.isWindows) {
       return join(
-          homedir(),
-          'AppData',
-          'Local',
-          'Microsoft',
-          'WindowsApps',
-          binary.endsWith('.exe') ? binary : `${binary}.exe`,
+        homedir(),
+        'AppData',
+        'Local',
+        'Microsoft',
+        'WindowsApps',
+        binary.endsWith('.exe') ? binary : `${binary}.exe`,
       );
     } else {
       return join('/usr', 'local', 'bin', binary);
@@ -157,10 +159,14 @@ export abstract class AnchoreCliService implements Disposable, AsyncInit {
         let binPath = await this.extract(assetPath, this.storageDir);
         options?.logger?.log(`Extracted ${this.toolId} to ${binPath}`);
 
-        const res = await windowApi.showInformationMessage(`Do you want to install ${this.toolId} system-wide?`, 'Cancel', 'Confirm');
-        if(res === 'Confirm') {
+        const res = await windowApi.showInformationMessage(
+          `Do you want to install ${this.toolId} system-wide?`,
+          'Cancel',
+          'Confirm',
+        );
+        if (res === 'Confirm') {
           const systemWidePath = await this.installSystemWide(binPath);
-          if(systemWidePath) {
+          if (systemWidePath) {
             binPath = systemWidePath;
           }
         }
@@ -200,7 +206,7 @@ export abstract class AnchoreCliService implements Disposable, AsyncInit {
 
   protected async where(): Promise<string | undefined> {
     try {
-      if(envApi.isWindows) {
+      if (envApi.isWindows) {
         const { stdout: path } = await extensionApi.process.exec('where', [this.toolId]);
         // remove all line break/carriage return characters from full path
         return path.replace(/(\r\n|\n|\r)/gm, '');
@@ -219,11 +225,11 @@ export abstract class AnchoreCliService implements Disposable, AsyncInit {
     let source: CliToolInstallationSource;
 
     let binaryPath: string;
-    if(systemBinaryPath) {
+    if (systemBinaryPath) {
       binaryPath = systemBinaryPath;
       source = this.getSystemBinaryPath() === binaryPath ? 'extension' : 'external';
     } else {
-      binaryPath = this.internalBinaryPath
+      binaryPath = this.internalBinaryPath;
       source = 'extension';
     }
 
@@ -235,8 +241,8 @@ export abstract class AnchoreCliService implements Disposable, AsyncInit {
     return {
       path: binaryPath,
       version: version ?? text,
-      source
-    }
+      source,
+    };
   }
 
   async init(): Promise<void> {
@@ -279,7 +285,7 @@ export abstract class AnchoreCliService implements Disposable, AsyncInit {
 
         await rm(this.storageDir, { recursive: true, force: true, maxRetries: 2, retryDelay: 5_000 });
 
-        if(this.cliTool?.path === this.getSystemBinaryPath()) {
+        if (this.cliTool?.path === this.getSystemBinaryPath()) {
           const command = extensionApi.env.isWindows ? 'del' : 'rm';
 
           try {
@@ -287,7 +293,7 @@ export abstract class AnchoreCliService implements Disposable, AsyncInit {
             await extensionApi.process.exec(command, [this.cliTool.path], { isAdmin: true });
           } catch (error) {
             console.error(`Failed to uninstall '${this.cliTool.path}'`, {
-              error
+              error,
             });
             throw error;
           }

--- a/packages/backend/src/services/anchore-cli-service.ts
+++ b/packages/backend/src/services/anchore-cli-service.ts
@@ -25,7 +25,12 @@ import type {
   QuickPickItem,
   TelemetryLogger,
 } from '@podman-desktop/api';
-import extensionApi, { cli as cliApi, env as envApi, process as processApi, window as windowApi } from '@podman-desktop/api';
+import extensionApi, {
+  cli as cliApi,
+  env as envApi,
+  process as processApi,
+  window as windowApi,
+} from '@podman-desktop/api';
 import type { AsyncInit } from '/@/utils/async-init';
 import type { Octokit } from '@octokit/rest';
 import { arch as nodeArch, platform as nodePlatform } from 'node:process';

--- a/packages/backend/src/services/anchore-cli-service.ts
+++ b/packages/backend/src/services/anchore-cli-service.ts
@@ -211,14 +211,13 @@ export abstract class AnchoreCliService implements Disposable, AsyncInit {
 
   protected async where(): Promise<string | undefined> {
     try {
-      if (envApi.isWindows) {
-        const { stdout: path } = await extensionApi.process.exec('where', [this.toolId]);
-        // remove all line break/carriage return characters from full path
-        return path.replace(/(\r\n|\n|\r)/gm, '');
-      } else {
-        const { stdout: path } = await extensionApi.process.exec('which', [this.toolId]);
-        return path;
-      }
+      const command = envApi.isWindows ? 'where' : 'which';
+      const { stdout } = await processApi.exec(command, [this.toolId]);
+      return stdout
+        .split(/\r?\n/)
+        .map(path => path.trim())
+        .find(Boolean);
+      // eslint-disable-next-line sonarjs/no-ignored-exceptions
     } catch (_: unknown) {
       return undefined;
     }
@@ -253,14 +252,12 @@ export abstract class AnchoreCliService implements Disposable, AsyncInit {
   async init(): Promise<void> {
     let info: InstallationInfo | undefined;
 
-    if (existsSync(this.internalBinaryPath)) {
-      try {
-        info = await this.getInstalledInfo();
-      } catch (err) {
-        console.warn('Unable to determine installed version', err);
-        // if unable to determine version, keep undefined and let user reinstall
-        info = undefined;
-      }
+    try {
+      info = await this.getInstalledInfo();
+    } catch (err) {
+      console.warn('Unable to determine installed version', err);
+      // if unable to determine version, keep undefined and let user reinstall
+      info = undefined;
     }
 
     // Ensure tool-specific storage folder exists early

--- a/packages/backend/src/services/anchore-cli-service.ts
+++ b/packages/backend/src/services/anchore-cli-service.ts
@@ -16,8 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type {
-  CliTool,
+import  {
+  CliTool, CliToolInstallationSource,
   Disposable,
   ExtensionContext,
   Logger,
@@ -34,10 +34,16 @@ import * as tar from 'tar';
 import { chmod, mkdir, rm, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { TELEMETRY_EVENTS } from '/@/utils/telemetry';
+import {homedir} from "node:os";
+import extensionApi from "@podman-desktop/api";
 
 export interface GithubReleaseMetadata extends QuickPickItem {
   tag: string;
   id: number;
+}
+
+export interface InstallationInfo {
+  path: string; version: string; source: CliToolInstallationSource
 }
 
 export const ANCHORE_GITHUB_ORG = 'anchore';
@@ -57,6 +63,57 @@ export abstract class AnchoreCliService implements Disposable, AsyncInit {
   protected abstract get markdownDescription(): string;
   protected abstract get repoName(): string; // e.g. 'syft' | 'grype'
   protected abstract get icon(): string;
+
+  protected getSystemBinaryPath(): string {
+    const binary = this.toolId;
+
+    if(envApi.isWindows) {
+      return join(
+          homedir(),
+          'AppData',
+          'Local',
+          'Microsoft',
+          'WindowsApps',
+          binary.endsWith('.exe') ? binary : `${binary}.exe`,
+      );
+    } else {
+      return join('/usr', 'local', 'bin', binary);
+    }
+  }
+
+  protected async installSystemWide(binaryPath: string): Promise<string | undefined> {
+    // Create the appropriate destination path (Windows uses AppData/Local, Linux and Mac use /usr/local/bin)
+    // and the appropriate command to move the binary to the destination path
+    const destinationPath: string = this.getSystemBinaryPath();
+    let command: string;
+    let args: string[];
+    if (envApi.isWindows) {
+      command = 'copy';
+      args = [`"${binaryPath}"`, `"${destinationPath}"`];
+    } else {
+      command = 'cp';
+      args = [binaryPath, destinationPath];
+    }
+
+    // If on macOS or Linux, check to see if the /usr/local/bin directory exists,
+    // if it does not, then add mkdir -p /usr/local/bin to the start of the command when moving the binary.
+    const localBinDir = '/usr/local/bin';
+    if ((envApi.isLinux || envApi.isMac) && !existsSync(localBinDir)) {
+      await processApi.exec('mkdir', ['-p', localBinDir], { isAdmin: true });
+    }
+
+    try {
+      // Use admin prileges / ask for password for copying to /usr/local/bin
+      await processApi.exec(command, args, { isAdmin: true });
+      console.log(`Successfully installed '${this.toolId}' binary.`);
+      return destinationPath;
+    } catch (error) {
+      console.error(`Failed to copy ${binaryPath} to ${destinationPath}`, {
+        error,
+      });
+      throw error;
+    }
+  }
 
   /**
    * Cancel all task related to the binary
@@ -97,8 +154,16 @@ export abstract class AnchoreCliService implements Disposable, AsyncInit {
       options?.logger?.log(`Downloaded ${this.toolId} to ${assetPath}`);
 
       try {
-        const binPath = await this.extract(assetPath, this.storageDir);
+        let binPath = await this.extract(assetPath, this.storageDir);
         options?.logger?.log(`Extracted ${this.toolId} to ${binPath}`);
+
+        const res = await windowApi.showInformationMessage(`Do you want to install ${this.toolId} system-wide?`, 'Cancel', 'Confirm');
+        if(res === 'Confirm') {
+          const systemWidePath = await this.installSystemWide(binPath);
+          if(systemWidePath) {
+            binPath = systemWidePath;
+          }
+        }
 
         this.cliTool?.updateVersion({
           version: selected.tag.slice(1),
@@ -125,7 +190,7 @@ export abstract class AnchoreCliService implements Disposable, AsyncInit {
     return this.toolId;
   }
 
-  protected get binaryPath(): string {
+  protected get internalBinaryPath(): string {
     return join(this.storageDir, envApi.isWindows ? `${this.binaryBaseName}.exe` : this.binaryBaseName);
   }
 
@@ -133,25 +198,57 @@ export abstract class AnchoreCliService implements Disposable, AsyncInit {
     this.cliTool?.dispose();
   }
 
-  protected async getInstalledVersion(): Promise<string> {
+  protected async where(): Promise<string | undefined> {
+    try {
+      if(envApi.isWindows) {
+        const { stdout: path } = await extensionApi.process.exec('where', [this.toolId]);
+        // remove all line break/carriage return characters from full path
+        return path.replace(/(\r\n|\n|\r)/gm, '');
+      } else {
+        const { stdout: path } = await extensionApi.process.exec('which', [this.toolId]);
+        return path;
+      }
+    } catch (_: unknown) {
+      return undefined;
+    }
+  }
+
+  protected async getInstalledInfo(): Promise<InstallationInfo> {
+    const systemBinaryPath = await this.where();
+
+    let source: CliToolInstallationSource;
+
+    let binaryPath: string;
+    if(systemBinaryPath) {
+      binaryPath = systemBinaryPath;
+      source = this.getSystemBinaryPath() === binaryPath ? 'extension' : 'external';
+    } else {
+      binaryPath = this.internalBinaryPath
+      source = 'extension';
+    }
+
     // default parse: '<tool> <semver>' from '--version'
-    const { stdout } = await processApi.exec(this.binaryPath, ['--version']);
+    const { stdout } = await processApi.exec(binaryPath, ['--version']);
     // example: 'syft 1.41.2' or 'grype 0.109.0'
     const text = stdout.trim();
     const [, version] = text.split(/\s+/);
-    return version ?? text;
+    return {
+      path: binaryPath,
+      version: version ?? text,
+      source
+    }
   }
 
   async init(): Promise<void> {
-    let version: string | undefined;
+    let info: InstallationInfo | undefined;
 
-    if (existsSync(this.binaryPath)) {
+    if (existsSync(this.internalBinaryPath)) {
       try {
-        version = await this.getInstalledVersion();
+        info = await this.getInstalledInfo();
       } catch (err) {
         console.warn('Unable to determine installed version', err);
         // if unable to determine version, keep undefined and let user reinstall
-        version = undefined;
+        info = undefined;
       }
     }
 
@@ -166,9 +263,9 @@ export abstract class AnchoreCliService implements Disposable, AsyncInit {
         icon: this.icon,
         logo: this.icon,
       },
-      version,
-      installationSource: 'extension',
-      path: version ? this.binaryPath : undefined,
+      version: info?.version,
+      installationSource: info?.source,
+      path: info?.path,
     });
 
     let selected: GithubReleaseMetadata | undefined = undefined;
@@ -181,13 +278,27 @@ export abstract class AnchoreCliService implements Disposable, AsyncInit {
         }
 
         await rm(this.storageDir, { recursive: true, force: true, maxRetries: 2, retryDelay: 5_000 });
+
+        if(this.cliTool?.path === this.getSystemBinaryPath()) {
+          const command = extensionApi.env.isWindows ? 'del' : 'rm';
+
+          try {
+            // Use admin prileges
+            await extensionApi.process.exec(command, [this.cliTool.path], { isAdmin: true });
+          } catch (error) {
+            console.error(`Failed to uninstall '${this.cliTool.path}'`, {
+              error
+            });
+            throw error;
+          }
+        }
       },
       doInstall: async (logger: Logger) => {
         if (!selected) throw new Error('No version selected');
         return this.install(selected, { logger });
       },
       selectVersion: async (_?: boolean) => {
-        const current = version; // already resolved above
+        const current = info; // already resolved above
         selected = await this.promptUserForVersion(current ? `v${current}` : undefined);
         return selected.tag.slice(1);
       },

--- a/packages/backend/src/services/grype-service.spec.ts
+++ b/packages/backend/src/services/grype-service.spec.ts
@@ -156,7 +156,7 @@ describe('GrypeService#analyse', () => {
 
     const result = await fn({ report: vi.fn() }, { isCancellationRequested: false, onCancellationRequested: vi.fn() });
 
-    expect(process.exec).toHaveBeenCalledExactlyOnceWith(
+    expect(process.exec).toHaveBeenCalledWith(
       CLI_TOOL_MOCK.path,
       [`sbom:${sbom}`, '--output=json', '--file=foo.grype.json.tmp'],
       {

--- a/packages/backend/src/services/syft-service.spec.ts
+++ b/packages/backend/src/services/syft-service.spec.ts
@@ -168,7 +168,7 @@ describe('SyftService#analyse', () => {
     const dest = join(CACHE_SERVICE_MOCK.getCacheDirectory(), IMAGE_INFO_MOCK.engineId, 'foo.syft.json');
     const tmp = `${dest}.tmp`;
 
-    expect(process.exec).toHaveBeenCalledExactlyOnceWith(
+    expect(process.exec).toHaveBeenCalledWith(
       CLI_TOOL_MOCK.path,
       ['scan', join(tmpdir(), IMAGE_INFO_MOCK.Id), `--output=json=${tmp}`],
       {


### PR DESCRIPTION
## Description

Supporting installing `grype` and `syft` binaries system wide (optional).

## Screenshots

https://github.com/user-attachments/assets/254b5895-d1e1-4719-9600-3242871fa144

<img width="1066" height="733" alt="image" src="https://github.com/user-attachments/assets/bb87a5e2-304a-43d8-a508-825b6e5344c3" />

## Related issues

Fixes https://github.com/podman-desktop/extension-grype/issues/229

## Testing

- [x] unit tests have been added