### PR TITLE
fix(release.yaml): use PODMAN_DESKTOP_BOT_TOKEN to push tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,6 +50,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.inputs.branch }}
+          token: ${{ secrets.PODMAN_DESKTOP_BOT_TOKEN }}
       - name: Generate tag utilities
         id: TAG_UTIL
         run: |


### PR DESCRIPTION
Fixes https://github.com/podman-desktop/extension-grype/issues/110

When we use the default GITHUB_TOKEN it does not trigger other workflows (Such as npmjs-publish.yaml)