### PR TITLE
fix: resolve CVE-2026-59869 in js-yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
       "postcss@<8.5.12": "^8.5.12",
       "svelte": ">=5.55.7",
       "esbuild": ">=0.28.1",
-      "js-yaml": ">=4.2.0"
+      "js-yaml@>=4.0.0 <5.0.0": "4.3.0",
+      "js-yaml@>=5.0.0": "5.2.1"
     }
   },
   "packageManager": "pnpm@10.15.0+sha512.486ebc259d3e999a4e8691ce03b5cac4a71cbeca39372a9b762cb500cfdf0873e2cb16abe3d951b1ee2cf012503f027b98b6584e4df22524e0c7450d9ec7aa7b"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,8 @@ overrides:
   postcss@<8.5.12: ^8.5.12
   svelte: '>=5.55.7'
   esbuild: '>=0.28.1'
-  js-yaml: '>=4.2.0'
+  js-yaml@>=4.0.0 <5.0.0: 4.3.0
+  js-yaml@>=5.0.0: 5.2.1
 
 importers:
 
@@ -1995,12 +1996,8 @@ packages:
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
-    hasBin: true
-
-  js-yaml@5.2.1:
-    resolution: {integrity: sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -2989,7 +2986,7 @@ snapshots:
     dependencies:
       '@jsdevtools/ono': 7.1.3
       '@types/json-schema': 7.0.15
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
 
   '@babel/helper-string-parser@7.29.7': {}
 
@@ -3085,7 +3082,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 5.2.1
+      js-yaml: 4.3.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -4956,11 +4953,7 @@ snapshots:
 
   js-tokens@10.0.0: {}
 
-  js-yaml@4.2.0:
-    dependencies:
-      argparse: 2.0.1
-
-  js-yaml@5.2.1:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -4974,7 +4967,7 @@ snapshots:
       '@types/json-schema': 7.0.15
       '@types/lodash': 4.17.24
       is-glob: 4.0.3
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       lodash: 4.18.1
       minimist: 1.2.8
       prettier: 3.8.1


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability CVE-2026-59869 in `js-yaml`.

**Advisory**: js-yaml: YAML merge-key chains can force quadratic CPU consumption
**Vulnerable versions**: >=4.0.0 <4.3.0
**Patched versions**: >=4.3.0
**Advisory URL**: https://github.com/advisories/GHSA-52cp-r559-cp3m

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-59869: _js-yaml: YAML merge-key chains can force quadratic CPU consumption_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-59869 is no longer reported