### PR TITLE
fix(binaries): sequential install

### DIFF
--- a/packages/backend/src/services/api-service.ts
+++ b/packages/backend/src/services/api-service.ts
@@ -59,7 +59,8 @@ export class ApiService implements AsyncInit<never, GrypeExtensionApi> {
         title: 'Installing Grype binaries',
       },
       async () => {
-        await Promise.all([this.syftService.install(), this.grypeService.install()]);
+        await this.syftService.install();
+        await this.grypeService.install();
       },
     );
   }

--- a/packages/backend/src/services/image-checker-provider.spec.ts
+++ b/packages/backend/src/services/image-checker-provider.spec.ts
@@ -193,6 +193,47 @@ describe('check', () => {
     );
   });
 
+  test('cli tools should be installed sequentially', async () => {
+    vi.mocked(window.withProgress).mockImplementation((_, fn) => {
+      return fn({ report: vi.fn() }, {} as CancellationToken);
+    });
+
+    const { promise: syftInstallPromise, resolve: syftResolve } = Promise.withResolvers<void>();
+    const { promise: grypeInstallPromise, resolve: grypeResolve } = Promise.withResolvers<void>();
+    vi.mocked(SYFT_SERVICE_MOCK.install).mockReturnValue(syftInstallPromise);
+    vi.mocked(GRYPE_SERVICE_MOCK.install).mockReturnValue(grypeInstallPromise);
+
+    vi.mocked(SYFT_SERVICE_MOCK.analyse).mockResolvedValue('sbom-path');
+    vi.mocked(GRYPE_SERVICE_MOCK.analyse).mockResolvedValue({
+      matches: [],
+    });
+
+    vi.mocked(SYFT_SERVICE_MOCK.isInstalled).mockReturnValue(false);
+    vi.mocked(GRYPE_SERVICE_MOCK.isInstalled).mockReturnValue(false);
+
+    // mock user confirm
+    vi.mocked(window.showInformationMessage).mockResolvedValue('Yes');
+
+    const checkPromise = check(IMAGE_INFO_MOCK);
+
+    await vi.waitFor(() => {
+      expect(SYFT_SERVICE_MOCK.install).toHaveBeenCalled();
+    });
+    expect(GRYPE_SERVICE_MOCK.install).not.toHaveBeenCalled();
+
+    syftResolve();
+
+    await vi.waitFor(() => {
+      expect(GRYPE_SERVICE_MOCK.install).toHaveBeenCalled();
+    });
+
+    grypeResolve();
+
+    await checkPromise;
+
+    expect(GRYPE_SERVICE_MOCK.install).toHaveBeenCalledAfter(vi.mocked(SYFT_SERVICE_MOCK.install));
+  });
+
   test('cli not installed should install them on user confirm', async () => {
     vi.mocked(window.withProgress).mockImplementation((_, fn) => {
       return fn({ report: vi.fn() }, {} as CancellationToken);

--- a/packages/backend/src/services/image-checker-provider.ts
+++ b/packages/backend/src/services/image-checker-provider.ts
@@ -69,7 +69,8 @@ export class ImageCheckerProvider implements Disposable, AsyncInit {
           title: 'Installing Grype binaries',
         },
         async () => {
-          await Promise.all([this.syft.install(), this.grype.install()]);
+          await this.syft.install();
+          await this.grype.install();
         },
       );
     }


### PR DESCRIPTION
## Description

The extension should not try to install in parallel the binaries, because it will display a popup to ask to install system-wide, but sending more than one `showInformationMessage` will discard any previous one without resolving/rejecting the promise. Leading to a never ending promise. Upstream issue https://github.com/podman-desktop/podman-desktop/issues/18592

## Related issues

Fixes https://github.com/podman-desktop/extension-grype/issues/281

## Testing

1. Uninstall both binaries
2. Go to any image details, in the `Check` tab
3. Accept to install binaries
4. Assert you see both dialog sequentially 